### PR TITLE
Make the iOS version of adobe-mobile-services work for android too.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -40,10 +40,14 @@
 	         <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 		 </config-file>
 		 <config-file target="AndroidManifest.xml" parent="/manifest/application">
+		 <!--
 			 <activity android:name="com.adobe.mobile.MessageFullScreenActivity" android:theme="@android:style/Theme.Translucent" />
+		  -->
 			 <receiver android:name="com.adobe.mobile.MessageNotificationHandler" />
 		 </config-file>
 		 <source-file src="sdks/Cordova/ADBMobile/Android/ADBMobile_PhoneGap.java" target-dir="src/com/adobe/" />
+		 <!--
 		 <source-file src="sdks/Android/AdobeMobileLibrary/adobeMobileLibrary-4.8.3.jar" target-dir="libs" />
+		  -->
 	 </platform>
 </plugin>


### PR DESCRIPTION
- don't allow mobile-services to generate MessageFullScreenActivity
- don't allow mobile-services to copy adobeMobileLibrary jar
